### PR TITLE
feat: Organizations Sweeper

### DIFF
--- a/internal/provider/organizations_admin_resource_test.go
+++ b/internal/provider/organizations_admin_resource_test.go
@@ -40,7 +40,7 @@ func TestAccOrganizationsAdminResource(t *testing.T) {
 			{
 				Config: testAccOrganizationsAdminResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "name", "testAdmin"),
+					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "name", "test_acc_admin"),
 					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "email", "meraki_organizations_admin_test_2023_06_05@example.com"),
 					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "org_access", "read-only"),
 					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "authentication_method", "Email"),
@@ -99,7 +99,7 @@ resource "meraki_network" "test" {
 resource "meraki_organizations_admin" "test" {
 	depends_on = ["meraki_organization.test", "meraki_network.test"]
 	organization_id = resource.meraki_organization.test.organization_id
-	name        = "testAdmin"
+	name        = "test_acc_admin"
 	email       = "meraki_organizations_admin_test_2023_06_05@example.com"
 	org_access   = "read-only"
 	authentication_method = "Email"
@@ -125,7 +125,7 @@ resource "meraki_network" "test" {
 resource "meraki_organizations_admin" "test" {
 	depends_on = ["meraki_organization.test", "meraki_network.test"]
 	organization_id = resource.meraki_organization.test.organization_id
-	name        = "testAdmin"
+	name        = "test_acc_admin"
 	email       = "meraki_organizations_admin_test_2023_06_05@example.com"
 	org_access   = "read-only"
 	authentication_method = "Email"

--- a/internal/provider/organizations_admins_data_source_test.go
+++ b/internal/provider/organizations_admins_data_source_test.go
@@ -23,7 +23,7 @@ func TestAccOrganizationsAdminsDataSource(t *testing.T) {
 			{
 				Config: testAccOrganizationsAdminsDataSourceConfigCreateAdmin,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "name", "testAdmin"),
+					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "name", "test_acc_admin"),
 					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "email", "meraki_organizations_admin_datasource_test1@example.com"),
 					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "org_access", "read-only"),
 					resource.TestCheckResourceAttr("meraki_organizations_admin.test", "authentication_method", "Email"),
@@ -41,7 +41,7 @@ func TestAccOrganizationsAdminsDataSource(t *testing.T) {
 					//resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "organization_id", ""),
 					resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.#", "2"),
 					//resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.1.id", ""),
-					resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.1.name", "testAdmin"),
+					resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.1.name", "test_acc_admin"),
 					resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.1.email", "meraki_organizations_admin_datasource_test1@example.com"),
 					resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.1.org_access", "read-only"),
 					// resource.TestCheckResourceAttr("data.meraki_organizations_admins.test", "list.1.account_status", ""),
@@ -72,7 +72,7 @@ resource "meraki_organization" "test" {}
 resource "meraki_organizations_admin" "test" {
 	depends_on = ["meraki_organization.test"]
 	organization_id = resource.meraki_organization.test.organization_id
-	name        = "testAdmin"
+	name        = "test_acc_admin"
 	email       = "meraki_organizations_admin_datasource_test1@example.com"
 	org_access   = "read-only"
 	authentication_method = "Email"

--- a/internal/provider/organizations_resource_test.go
+++ b/internal/provider/organizations_resource_test.go
@@ -1,9 +1,77 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"strings"
 	"testing"
 )
+
+func init() {
+	resource.AddTestSweepers("meraki_organization", &resource.Sweeper{
+		Name: "meraki_organization",
+
+		// The Organization used in acceptance tests
+		F: func(organization string) error {
+			client, err := SweeperHTTPClient()
+			if err != nil {
+				return fmt.Errorf("error getting http client: %s", err)
+			}
+
+			// Search test organization for networks
+			inlineResp, _, err := client.OrganizationsApi.GetOrganizations(context.Background()).Execute()
+			if err != nil {
+				return fmt.Errorf("error getting organizations list from Meraki API:%s\n", err)
+			}
+
+			// List of Organizations
+			for _, merakiOrganization := range inlineResp {
+
+				// match on organizations starting with "test_acc" in name
+				if strings.HasPrefix(*merakiOrganization.Name, "test") {
+					fmt.Printf("deleting organization: %s, id: %s\n", *merakiOrganization.Name, *merakiOrganization.Id)
+
+					// Check for Networks
+					perPage := int32(100000)
+					inlineRespNetwork, _, err1 := client.NetworksApi.GetOrganizationNetworks(context.Background(), *merakiOrganization.Id).PerPage(perPage).Execute()
+					if err1 != nil {
+						return fmt.Errorf("error getting network list from organization:%s error: %s\n", *merakiOrganization.Id, err1)
+					}
+
+					for _, merakiNetwork := range inlineRespNetwork {
+						fmt.Printf("deleting network: %s, id: %s\n", *merakiNetwork.Name, *merakiNetwork.Id)
+
+						// Delete test network
+						networkHttpResp, err2 := client.NetworksApi.DeleteNetwork(context.Background(), *merakiNetwork.Id).Execute()
+						if err2 != nil {
+							fmt.Printf("%v\n", networkHttpResp)
+						}
+
+						if networkHttpResp.StatusCode == 204 {
+							fmt.Printf("Successfully deleted network: %s, id: %s\n", *merakiNetwork.Name, *merakiNetwork.Id)
+						}
+					}
+
+					// TODO: Delete admins
+
+					// TODO: Org Inventory Devices (No api endpoint)
+
+					// Delete test Organization
+					httpRespOrg, err3 := client.OrganizationsApi.DeleteOrganization(context.Background(), *merakiOrganization.Id).Execute()
+					if err3 != nil {
+						fmt.Printf("%v\n", httpRespOrg.Body)
+					}
+					if httpRespOrg.StatusCode == 204 {
+						fmt.Printf("Successfully deleted organization: %s, id: %s\n", *merakiOrganization.Name, *merakiOrganization.Id)
+					}
+
+				}
+			}
+
+			return nil
+		}})
+}
 
 func TestAccOrganizationResource(t *testing.T) {
 


### PR DESCRIPTION
Created Organization sweeper with the ability to delete:

Orgainizations starting with "test_acc" and underlying networks.

TODO:

- Add scan & delete for admins prefixed with "test_acc"
- Wait for unclaim device from the orgainzation endpoint