### PR TITLE
Add port_id and serial to the device switch port import

### DIFF
--- a/internal/provider/devices_switch_port_resource.go
+++ b/internal/provider/devices_switch_port_resource.go
@@ -562,7 +562,7 @@ func (r *DevicesSwitchPortResource) ImportState(ctx context.Context, req resourc
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: organization_id, network_id. Got: %q", req.ID),
+			fmt.Sprintf("Expected import identifier with format: serial, port_id. Got: %q", req.ID),
 		)
 		return
 	}
@@ -774,7 +774,7 @@ func DevicesSwitchPortResourceResponse(ctx context.Context, response *openApiCli
 		return data, diags
 	}
 	data.LinkNegotiationCapabilities = listValue
-	data.Id = jsontypes.StringValue("example-id")
+	data.Id = jsontypes.StringValue(data.Serial.ValueString() + "," + data.PortId.ValueString())
 
 	return data, nil
 }

--- a/internal/provider/devices_switch_port_resource_test.go
+++ b/internal/provider/devices_switch_port_resource_test.go
@@ -39,8 +39,7 @@ func TestAccDevicesSwitchPortResource(t *testing.T) {
 			{
 				Config: testAccDevicesSwitchPortResourceConfigRead(os.Getenv("TF_ACC_MERAKI_ORGANIZATION_ID"), os.Getenv("TF_ACC_MERAKI_MS_SERIAL")),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "id", "example-id"),
-					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "port_id", "1"),
+					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "port_id", "2"),
 					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "poe_enabled", "true"),
 					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "type", "access"),
@@ -57,6 +56,13 @@ func TestAccDevicesSwitchPortResource(t *testing.T) {
 					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "profile.iname", ""),
 					resource.TestCheckResourceAttr("meraki_devices_switch_port.test", "profile.id", "0"),
 				),
+			},
+
+			// ImportState test case.
+			{
+				ResourceName:      "meraki_devices_switch_port.test",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -99,7 +105,7 @@ resource "meraki_devices_switch_port" "test" {
 	serial = "%s"
 	name = "My switch port"	
 	tags = ["tag1", "tag2"]
-	port_id = 1
+	port_id = 2
 	enabled = true
 	type = "access"
 	poe_enabled = true


### PR DESCRIPTION
Currently switch port resource is taking only the serial number of the device in the import. we should send both serial and the port_id in the import for importing the existing port