### PR TITLE
Resolve Issue 314

### DIFF
--- a/internal/provider/devices_switch_port_resource.go
+++ b/internal/provider/devices_switch_port_resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -214,9 +213,6 @@ func (r *DevicesSwitchPortResource) Schema(ctx context.Context, req resource.Sch
 				CustomType:          jsontypes.BoolType,
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"adaptive_policy_group_id": schema.StringAttribute{
 				MarkdownDescription: "The adaptive policy group ID that will be used to tag traffic through this switch port. This ID must pre-exist during the configuration, else needs to be created using adaptivePolicy/groups API. Cannot be applied to a port on a switch bound to profile.",
@@ -235,9 +231,6 @@ func (r *DevicesSwitchPortResource) Schema(ctx context.Context, req resource.Sch
 				CustomType:          jsontypes.BoolType,
 				Optional:            true,
 				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"dai_trusted": schema.BoolAttribute{
 				MarkdownDescription: "If true, ARP packets for this port will be considered trusted, and Dynamic ARP Inspection will allow the traffic.",


### PR DESCRIPTION
Remove the `UseStateForUnknown` plan modifier from the `storm_control_enabled` and `flexible_stacking_enabled` attributes so a user-provided `null` value is used in resource update calls.

Resolves issue #314 