### PR TITLE
Fix three issues with the meraki_networks_appliance_vlans resource

### DIFF
--- a/docs/resources/networks_appliance_vlans.md
+++ b/docs/resources/networks_appliance_vlans.md
@@ -61,9 +61,12 @@ Optional:
 <a id="nestedatt--fixed_ip_assignments"></a>
 ### Nested Schema for `fixed_ip_assignments`
 
-Optional:
+Required:
 
 - `ip` (String) Enable IPv6 on VLAN.
+
+Optional:
+
 - `name` (String) Enable IPv6 on VLAN.
 
 

--- a/internal/provider/networks_appliance_vlan_resource.go
+++ b/internal/provider/networks_appliance_vlan_resource.go
@@ -1009,7 +1009,7 @@ func ReadHttpResponse(ctx context.Context, data *NetworksApplianceVLANsResourceM
 				"name": types.StringValue(assignmentInterface.GetName()),
 			}
 
-			fixedIpAssignmentValue, fixedIpAssignmentsDiags := types.ObjectValueFrom(ctx, fixedIpAssignmentAttrTypes, fixedIpAssignmentObject)
+			fixedIpAssignmentValue, fixedIpAssignmentsDiags := types.ObjectValue(fixedIpAssignmentAttrTypes, fixedIpAssignmentObject)
 			if fixedIpAssignmentsDiags.HasError() {
 				resp.Append(fixedIpAssignmentsDiags...)
 				continue

--- a/internal/provider/networks_appliance_vlan_resource.go
+++ b/internal/provider/networks_appliance_vlan_resource.go
@@ -794,8 +794,6 @@ func CreateHttpResponse(ctx context.Context, data *NetworksApplianceVLANsResourc
 
 	} else {
 		if data.IPv6.IsUnknown() {
-			tflog.Info(ctx, fmt.Sprintf("Empty IPv6 response: %v", data.IPv6))
-
 			ipv6Instance := NetworksApplianceVLANsResourceModelIpv6{}
 			ipv6Prefixes := []NetworksApplianceVLANsResourceModelIpv6PrefixAssignment{}
 
@@ -1235,8 +1233,6 @@ func ReadHttpResponse(ctx context.Context, data *NetworksApplianceVLANsResourceM
 		data.IPv6 = ipv6Object
 	} else {
 		if data.IPv6.IsUnknown() {
-			tflog.Info(ctx, fmt.Sprintf("Empty IPv6 response: %v", data.IPv6))
-
 			ipv6Instance := NetworksApplianceVLANsResourceModelIpv6{}
 			ipv6Prefixes := []NetworksApplianceVLANsResourceModelIpv6PrefixAssignment{}
 

--- a/internal/provider/networks_appliance_vlan_resource_test.go
+++ b/internal/provider/networks_appliance_vlan_resource_test.go
@@ -58,6 +58,7 @@ func TestAccNetworksApplianceVlansResource(t *testing.T) {
 					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "dhcp_boot_options_enabled", "true"),
 					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "dhcp_boot_next_server", "2.3.4.5"),
 					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "dhcp_boot_filename", "updated.file"),
+					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "list.0.fixed_ip_assignments.%", "0"),
 					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "reserved_ip_ranges.0.start", "192.168.2.0"),
 					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "reserved_ip_ranges.0.end", "192.168.2.1"),
 					resource.TestCheckResourceAttr("meraki_networks_appliance_vlans.test", "reserved_ip_ranges.0.comment", "A newly reserved IP range"),
@@ -212,6 +213,12 @@ resource "meraki_networks_appliance_vlans" "test" {
     dhcp_boot_options_enabled = true
     dhcp_boot_next_server = "2.3.4.5"
     dhcp_boot_filename = "updated.file"
+	fixed_ip_assignments = {
+		"22:33:44:55:66:77": {
+			"ip": "192.168.2.10",
+			"name": "Some client name"
+	  	}
+	}
     reserved_ip_ranges = [
         {
             start = "192.168.2.0"


### PR DESCRIPTION
Fixes three separate issues with the `meraki_networks_appliance_vlans` resource that we encountered when trying to define `fixed_ip_assignments` for a VLAN:

- null values for the `ipv6` attribute weren't properly handled, which was an open todo item.
  - This blocked updating a resource if the network doesn't support IPv6, and I addressed the open todo and resolved the same issue in a second method.
  - Attempting to update a resource with a null value leads to an invalid object since the attribute is computed and the provider wasn't setting a value for it if the input is null:
![image](https://github.com/core-infra-svcs/terraform-provider-meraki/assets/12103419/18b7790c-babe-4ced-b668-d0a10de58dd6)
  - Attempting to define the value with `ipv6.enabled` set to `false` to workaround the above issue leads to an unsupported response from the API if IPv6 isn't supported, so the provider needs to accept a null value:
![image](https://github.com/core-infra-svcs/terraform-provider-meraki/assets/12103419/678d3d61-150d-45da-ac6c-aefb336a18ab)
- After resolving that, applies with a `fixed_ip_assignments` value still failed due to a type casting issue in the method to generate the update call payload,
  - Using the ElementAs method to convert the plan's `fixed_ip_assignments` value directly to a `map[string]interface{}` silently failed consistently and the map value was always empty, causing the associated API request attribute to be empty.
  - Any time a value was provided for `fixed_ip_assignments`, this resulted in the value not being set properly, and by extension, an inconsistent result after apply error from Terraform:
![image](https://github.com/core-infra-svcs/terraform-provider-meraki/assets/12103419/b61b4320-203f-4405-b711-2f73d2c0b2e7)
- After resolving that, there was a third issue blocking `fixed_ip_assignments`, the provider threw a value conversion exception from the method to unmarshal the API read call response. Based on the existing parameter set, using the SDK's `ObjectValue` method is better than `ObjectValueFrom`.
![image](https://github.com/core-infra-svcs/terraform-provider-meraki/assets/12103419/b62f6755-b805-4c40-bc5c-bf7e9d16582b)

